### PR TITLE
Adding queue ops in Presto Backend Flow DSL to call redis queue ops

### DIFF
--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -23,7 +23,7 @@ module Presto.Backend.Flow where
 
 import Prelude
 
-import Cache (CacheConn, getQueueIdx)
+import Cache (CacheConn)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Free (Free, liftF)

--- a/src/Presto/Backend/Language/Interpreter.purs
+++ b/src/Presto/Backend/Language/Interpreter.purs
@@ -23,7 +23,7 @@ module Presto.Backend.Interpreter where
 
 import Prelude
 
-import Cache (CacheConn, delKey, expire, getHashKey, getKey, incr, publishToChannel, setHash, setKey, setMessageHandler, setex, subscribe, set)
+import Cache (CacheConn, delKey, enqueue, dequeue, expire, getHashKey, getKey, incr, publishToChannel, set, setHash, setKey, setMessageHandler, setex, subscribe, getQueueIdx)
 import Control.Monad.Aff (Aff, forkAff)
 import Control.Monad.Eff.Exception (Error, error)
 import Control.Monad.Except.Trans (ExceptT(..), lift, throwError, runExceptT) as E
@@ -103,6 +103,12 @@ interpret _ (PublishToChannel cacheConn channel message next) = (R.lift $ S.lift
 interpret _ (Subscribe cacheConn channel next) = (R.lift $ S.lift $ E.lift $ subscribe cacheConn channel) >>= (pure <<< next) 
 
 interpret _ (SetMessageHandler cacheConn f next) = (R.lift $ S.lift $ E.lift $ setMessageHandler cacheConn f) >>= (pure <<< next) 
+
+interpret _ (Enqueue cacheConn listName value next) = (R.lift $ S.lift $ E.lift $ enqueue cacheConn listName value) >>= (pure <<< next)
+
+interpret _ (Dequeue cacheConn listName next) = (R.lift $ S.lift $ E.lift $ dequeue cacheConn listName) >>= (pure <<< next)
+
+interpret _ (GetQueueIdx cacheConn listName index next) = (R.lift $ S.lift $ E.lift $ getQueueIdx cacheConn listName index) >>= (pure <<< next)
 
 interpret (BackendRuntime a connections c) (GetCacheConn cacheName next) = do
   maybeCache <- pure $ lookup cacheName connections


### PR DESCRIPTION
Providing DSL commands in Presto-BackendFlow to use Redis Queues.

As of now, only 3 operations are added: Enqueue, Dequeue and GetQueueIdx (get value for an index)