### PR TITLE
Update based on queue API fixes in purescript-redis

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "purescript-sequelize": "https://github.com/juspay/purescript-sequelize.git#0.1.2",
     "purescript-body-parser": "https://github.com/juspay/purescript-body-parser.git#0.1.0",
     "purescript-uuid": "^4.0.0",
-    "purescript-redis": "https://github.com/juspay/purescript-redis.git#0.1.1",
+    "purescript-redis": "https://github.com/juspay/purescript-redis.git#0.1.2",
     "purescript-now": "3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
(WARNING: this depends on to-be-reviewed changes in https://github.com/juspay/purescript-redis/pull/18)

purescript-redis has renamed enqueue/dequeue to underlying Redis
commands (rpop/lpush), and fixed the corresponding return types.