### PR TITLE
Update after purescript-redis refactor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,20 +20,24 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-express": "^0.5.0",
-    "purescript-presto": "^0.2.3",
-    "purescript-sequelize": "https://github.com/juspay/purescript-sequelize.git#0.1.2",
+    "purescript-express": "85ee5261a6cf3e8e2b5cd6b167f6c0fdd29d6f14",
+    "purescript-presto": "67dbec28260b39407eb528542f7fd7dbc32f0536",
+    "purescript-sequelize": "https://github.com/juspay/purescript-sequelize.git#cfc0c9245322520115eca7b2c1fa0d6bbcebf315",
     "purescript-body-parser": "https://github.com/juspay/purescript-body-parser.git#0.1.0",
     "purescript-uuid": "^4.0.0",
-    "purescript-redis": "https://github.com/juspay/purescript-redis.git#c1834956ed8e495d6e58a9935a58f9004452bcaf",
-    "purescript-now": "3.0.0"
+    "purescript-redis": "https://github.com/juspay/purescript-redis.git#042631881afc9898fdd395eed0992c0e07966376",
+    "purescript-now": "3.0.0",
+    "purescript-node-fs": "^4.0.0",
+    "purescript-node-process": "^5.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0"
   },
+  "version": "0.0.1",
   "resolutions": {
-    "purescript-aff-promise": "^0.7.0",
-    "purescript-foreign-generic": "5.0.0"
-  },
-  "version": "0.0.1"
+    "purescript-aff": "~4.0.0",
+    "purescript-foreign-generic": "^6.0.0",
+    "purescript-express": "85ee5261a6cf3e8e2b5cd6b167f6c0fdd29d6f14",
+    "purescript-test-unit": "^13.0.0"
+  }
 }

--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -23,15 +23,18 @@ module Presto.Backend.Flow where
 
 import Prelude
 
-import Cache (CacheConn, Multi)
+import Cache (CacheConn)
+import Cache.Multi (Multi)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Free (Free, liftF)
 import Data.Either (Either(..))
 import Data.Exists (Exists, mkExists)
+import Data.Foreign (Foreign)
 import Data.Foreign.Class (class Decode, class Encode)
 import Data.Maybe (Maybe(..))
 import Data.Options (Options)
+import Data.Time.Duration (Milliseconds, Seconds)
 import Presto.Backend.DB (findOne, findAll, create, createWithOpts, query, update, delete) as DB
 import Presto.Backend.Types (BackendAff)
 import Presto.Core.Types.API (class RestEndpoint, Headers)
@@ -41,7 +44,7 @@ import Presto.Core.Types.Language.Interaction (Interaction)
 import Sequelize.Class (class Model)
 import Sequelize.Types (Conn)
 
-data BackendFlowCommands next st rt s = 
+data BackendFlowCommands next st rt s =
       Ask (rt -> next)
     | Get (st -> next)
     | Put st (st -> next)
@@ -59,42 +62,40 @@ data BackendFlowCommands next st rt s =
     | GetDBConn String (Conn -> next)
     | GetCacheConn String (CacheConn -> next)
     | Log String s next
-    | SetWithOptions CacheConn (Array String) (Either Error String -> next)
-    | SetCache CacheConn String String (Either Error String -> next)
-    | SetCacheWithExpiry CacheConn String String String (Either Error String -> next)
-    | GetCache CacheConn String (Either Error String -> next)
+    | SetCache CacheConn String String (Either Error Unit -> next)
+    | SetCacheWithExpiry CacheConn String String Milliseconds (Either Error Unit -> next)
+    | GetCache CacheConn String (Either Error (Maybe String) -> next)
     | KeyExistsCache CacheConn String (Either Error Boolean -> next)
-    | DelCache CacheConn String (Either Error String -> next)
+    | DelCache CacheConn String (Either Error Int -> next)
     | Enqueue CacheConn String String (Either Error Unit -> next)
     | Dequeue CacheConn String (Either Error (Maybe String) -> next)
     | GetQueueIdx CacheConn String Int (Either Error (Maybe String) -> next)
     | Fork (BackendFlow st rt s) (Unit -> next)
-    | Expire CacheConn String String (Either Error String -> next)
-    | Incr CacheConn String (Either Error String -> next)
-    | SetHash CacheConn String String String (Either Error String -> next)
-    | GetHashKey CacheConn String String (Either Error String -> next)
-    | PublishToChannel CacheConn String String (Either Error String -> next)
-    | Subscribe CacheConn String (Either Error String -> next)
-    | SetMessageHandler CacheConn (forall eff. (String -> String -> Eff eff Unit)) (Either Error String -> next)
+    | Expire CacheConn String Seconds (Either Error Boolean -> next)
+    | Incr CacheConn String (Either Error Int -> next)
+    | SetHash CacheConn String String String (Either Error Boolean -> next)
+    | GetHashKey CacheConn String String (Either Error (Maybe String) -> next)
+    | PublishToChannel CacheConn String String (Either Error Int -> next)
+    | Subscribe CacheConn String (Either Error Unit -> next)
+    | SetMessageHandler CacheConn (forall eff. (String -> String -> Eff eff Unit)) (Unit -> next)
     | GetMulti CacheConn (Multi -> next)
     | SetCacheInMulti String String Multi (Multi -> next)
     | GetCacheInMulti String Multi (Multi -> next)
     | DelCacheInMulti String Multi (Multi -> next)
-    | SetCacheWithExpiryInMulti String String String Multi (Multi -> next)
-    | ExpireInMulti String String Multi (Multi -> next)
+    | SetCacheWithExpiryInMulti String String Milliseconds Multi (Multi -> next)
+    | ExpireInMulti String Seconds Multi (Multi -> next)
     | IncrInMulti String Multi (Multi -> next)
     | SetHashInMulti String String String Multi (Multi -> next)
     | GetHashInMulti String String Multi (Multi -> next)
-    | SetWithOptionsInMulti (Array String) Multi (Multi -> next)
     | PublishToChannelInMulti String String Multi (Multi -> next)
     | SubscribeInMulti String Multi (Multi -> next)
     | EnqueueInMulti String String Multi (Multi -> next)
     | DequeueInMulti String Multi (Multi -> next)
-    | GetQueueIdxInMulti String Int Multi (Multi -> next) 
-    | Exec Multi (Either Error (Array String) -> next) 
+    | GetQueueIdxInMulti String Int Multi (Multi -> next)
+    | Exec Multi (Either Error (Array Foreign) -> next)
     | RunSysCmd String (String -> next)
 
-    -- | HandleException 
+    -- | HandleException
     -- | Await (Control s) (s -> next)
     -- | Delay Milliseconds next
 
@@ -137,7 +138,7 @@ findAll dbName options = do
   conn <- getDBConn dbName
   model <- doAff do
         DB.findAll conn options
-  wrap $ FindAll model id 
+  wrap $ FindAll model id
 
 query :: forall a st rt. String -> String -> BackendFlow st rt (Either Error (Array a))
 query dbName rawq = do
@@ -186,19 +187,19 @@ getDBConn dbName = do
 getCacheConn :: forall st rt. String -> BackendFlow st rt CacheConn
 getCacheConn dbName = wrap $ GetCacheConn dbName id
 
-getMulti :: forall st rt. String -> BackendFlow st rt Multi
-getMulti cacheName = do
+newMulti :: forall st rt. String -> BackendFlow st rt Multi
+newMulti cacheName = do
     cacheConn <- getCacheConn cacheName
     wrap $ GetMulti cacheConn id
 
 callAPI :: forall st rt a b. Encode a => Decode b => RestEndpoint a b
   => Headers -> a -> BackendFlow st rt (APIResult b)
-callAPI headers a = wrap $ CallAPI (apiInteract a headers) id 
+callAPI headers a = wrap $ CallAPI (apiInteract a headers) id
 
 setCacheInMulti :: forall st rt. String -> String -> Multi -> BackendFlow st rt Multi
 setCacheInMulti key value multi = wrap $ SetCacheInMulti key value multi id
 
-setCache :: forall st rt. String -> String ->  String -> BackendFlow st rt (Either Error String)
+setCache :: forall st rt. String -> String ->  String -> BackendFlow st rt (Either Error Unit)
 setCache cacheName key value = do
   cacheConn <- getCacheConn cacheName
   wrap $ SetCache cacheConn key value id
@@ -206,7 +207,7 @@ setCache cacheName key value = do
 getCacheInMulti :: forall st rt. String -> Multi -> BackendFlow st rt Multi
 getCacheInMulti key multi = wrap $ GetCacheInMulti key multi id
 
-getCache :: forall st rt. String -> String -> BackendFlow st rt (Either Error String)
+getCache :: forall st rt. String -> String -> BackendFlow st rt (Either Error (Maybe String))
 getCache cacheName key = do
   cacheConn <- getCacheConn cacheName
   wrap $ GetCache cacheConn key id
@@ -219,15 +220,15 @@ keyExistsCache cacheName key = do
 delCacheInMulti :: forall st rt. String -> Multi -> BackendFlow st rt Multi
 delCacheInMulti key multi = wrap $ DelCacheInMulti key multi id
 
-delCache :: forall st rt. String -> String -> BackendFlow st rt (Either Error String)
+delCache :: forall st rt. String -> String -> BackendFlow st rt (Either Error Int)
 delCache cacheName key = do
   cacheConn <- getCacheConn cacheName
   wrap $ DelCache cacheConn key id
 
-setCacheWithExpireInMulti :: forall st rt. String -> String -> String -> Multi -> BackendFlow st rt Multi
+setCacheWithExpireInMulti :: forall st rt. String -> String -> Milliseconds -> Multi -> BackendFlow st rt Multi
 setCacheWithExpireInMulti key value ttl multi = wrap $ SetCacheWithExpiryInMulti key value ttl multi id
 
-setCacheWithExpiry :: forall st rt. String -> String -> String -> String -> BackendFlow st rt (Either Error String)
+setCacheWithExpiry :: forall st rt. String -> String -> String -> Milliseconds -> BackendFlow st rt (Either Error Unit)
 setCacheWithExpiry cacheName key value ttl = do
   cacheConn <- getCacheConn cacheName
   wrap $ SetCacheWithExpiry cacheConn key value ttl id
@@ -235,26 +236,26 @@ setCacheWithExpiry cacheName key value ttl = do
 log :: forall st rt a. String -> a -> BackendFlow st rt Unit
 log tag message = wrap $ Log tag message unit
 
-expireInMulti :: forall st rt. String -> String -> Multi -> BackendFlow st rt Multi
+expireInMulti :: forall st rt. String -> Seconds -> Multi -> BackendFlow st rt Multi
 expireInMulti key ttl multi = wrap $ ExpireInMulti key ttl multi id
 
-expire :: forall st rt. String -> String -> String -> BackendFlow st rt (Either Error String)
-expire cacheName key ttl = do 
+expire :: forall st rt. String -> String -> Seconds -> BackendFlow st rt (Either Error Boolean)
+expire cacheName key ttl = do
   cacheConn <- getCacheConn cacheName
   wrap $ Expire cacheConn key ttl id
 
 incrInMulti :: forall st rt. String -> Multi -> BackendFlow st rt Multi
 incrInMulti key multi = wrap $ IncrInMulti key multi id
 
-incr :: forall st rt. String -> String -> BackendFlow st rt (Either Error String)
+incr :: forall st rt. String -> String -> BackendFlow st rt (Either Error Int)
 incr cacheName key = do
   cacheConn <- getCacheConn cacheName
   wrap $ Incr cacheConn key id
 
 setHashInMulti :: forall st rt. String -> String -> String -> Multi -> BackendFlow st rt Multi
-setHashInMulti key field value multi = wrap $ SetHashInMulti key field value multi id 
+setHashInMulti key field value multi = wrap $ SetHashInMulti key field value multi id
 
-setHash :: forall st rt. String -> String -> String -> String -> BackendFlow st rt (Either Error String)
+setHash :: forall st rt. String -> String -> String -> String -> BackendFlow st rt (Either Error Boolean)
 setHash cacheName key field value = do
   cacheConn <- getCacheConn cacheName
   wrap $ SetHash cacheConn key field value id
@@ -262,23 +263,15 @@ setHash cacheName key field value = do
 getHashKeyInMulti :: forall st rt. String -> String -> Multi -> BackendFlow st rt Multi
 getHashKeyInMulti key field multi = wrap $ GetHashInMulti key field multi id
 
-getHashKey :: forall st rt. String -> String -> String -> BackendFlow st rt (Either Error String)
-getHashKey cacheName key field = do 
+getHashKey :: forall st rt. String -> String -> String -> BackendFlow st rt (Either Error (Maybe String))
+getHashKey cacheName key field = do
   cacheConn <- getCacheConn cacheName
-  wrap $ GetHashKey cacheConn key field id 
+  wrap $ GetHashKey cacheConn key field id
 
-setWithOptionsInMulti :: forall st rt. Array String -> Multi -> BackendFlow st rt Multi
-setWithOptionsInMulti arr multi = wrap $ SetWithOptionsInMulti  arr multi id
-
-setWithOptions :: forall st rt. String -> Array String -> BackendFlow st rt (Either Error String)
-setWithOptions cacheName arr = do
-  cacheConn <- getCacheConn cacheName
-  wrap $ SetWithOptions cacheConn arr id 
-  
 publishToChannelInMulti :: forall st rt. String -> String -> Multi -> BackendFlow st rt Multi
 publishToChannelInMulti channel message multi = wrap $ PublishToChannelInMulti channel message multi id
 
-publishToChannel :: forall st rt. String -> String -> String -> BackendFlow st rt (Either Error String)
+publishToChannel :: forall st rt. String -> String -> String -> BackendFlow st rt (Either Error Int)
 publishToChannel cacheName channel message = do
   cacheConn <- getCacheConn cacheName
   wrap $ PublishToChannel cacheConn channel message id
@@ -286,7 +279,7 @@ publishToChannel cacheName channel message = do
 subscribeToMulti :: forall st rt. String -> Multi -> BackendFlow st rt Multi
 subscribeToMulti channel multi = wrap $ SubscribeInMulti channel multi id
 
-subscribe :: forall st rt. String -> String -> BackendFlow st rt (Either Error String)
+subscribe :: forall st rt. String -> String -> BackendFlow st rt (Either Error Unit)
 subscribe cacheName channel = do
   cacheConn <- getCacheConn cacheName
   wrap $ Subscribe cacheConn channel id
@@ -315,10 +308,10 @@ getQueueIdx cacheName listName index = do
   cacheConn <- getCacheConn cacheName
   wrap $ GetQueueIdx cacheConn listName index id
 
-execMulti :: forall st rt. Multi -> BackendFlow st rt (Either Error (Array String))
+execMulti :: forall st rt. Multi -> BackendFlow st rt (Either Error (Array Foreign))
 execMulti multi = wrap $ Exec multi id
 
-setMessageHandler :: forall st rt. String -> (forall eff. (String -> String -> Eff eff Unit)) -> BackendFlow st rt (Either Error String)
+setMessageHandler :: forall st rt. String -> (forall eff. (String -> String -> Eff eff Unit)) -> BackendFlow st rt Unit
 setMessageHandler cacheName f = do
   cacheConn <- getCacheConn cacheName
   wrap $ SetMessageHandler cacheConn f id

--- a/src/Presto/Backend/Language/Interpreter.purs
+++ b/src/Presto/Backend/Language/Interpreter.purs
@@ -23,13 +23,18 @@ module Presto.Backend.Interpreter where
 
 import Prelude
 
-import Cache (CacheConn, delKey, exec, exists, expire, expireMulti, getHashKey, getHashKeyMulti, getKey, getKeyMulti, getMulti, incr, incrMulti, lindex, lindexMulti, lpop, lpopMulti, publishToChannel, publishToChannelMulti, rpush, rpushMulti, set, setHash, setHashMulti, setKey, setKeyMulti, setMessageHandler, setMulti, setex, setexKeyMulti, subscribe, subscribeMulti)
+import Cache (CacheConn, SetOptions(..), del, exists, expire, get, incr, publish, set, setMessageHandler, subscribe)
+import Cache.Hash (hget, hset)
+import Cache.List (lindex, lpop, rpush)
+import Cache.Multi (execMulti, expireMulti, getMulti, hgetMulti, hsetMulti, incrMulti, lindexMulti, lpopMulti, newMulti, publishMulti, rpushMulti, setMulti, subscribeMulti)
 import Control.Monad.Aff (Aff, forkAff)
+import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (Error, error)
 import Control.Monad.Except.Trans (ExceptT(..), lift, throwError, runExceptT) as E
 import Control.Monad.Free (foldFree)
 import Control.Monad.Reader.Trans (ReaderT, ask, lift, runReaderT) as R
 import Control.Monad.State.Trans (StateT, get, lift, modify, put, runStateT) as S
+import Data.Array.NonEmpty (singleton) as NEArray
 import Data.Either (Either(..))
 import Data.Exists (runExists)
 import Data.Maybe (Maybe(..))
@@ -81,31 +86,29 @@ interpret _ (ThrowException errorMessage next) = R.lift S.get >>= (R.lift <<< S.
 
 interpret _ (DoAff aff nextF) = (R.lift $ S.lift $ E.lift aff) >>= (pure <<< nextF)
 
-interpret _ (SetCache cacheConn key value next) = (R.lift $ S.lift $ E.lift $ setKey cacheConn key value) >>= (pure <<< next )
+interpret _ (SetCache cacheConn key value next) = (R.lift $ S.lift $ E.lift $ set cacheConn key value Nothing NoOptions) >>= (pure <<< next)
 
-interpret _ (SetCacheWithExpiry cacheConn key value ttl next) = (R.lift $ S.lift $ E.lift $ setex cacheConn key value ttl) >>= (pure <<< next)
+interpret _ (SetCacheWithExpiry cacheConn key value ttl next) = (R.lift $ S.lift $ E.lift $ set cacheConn key value (Just ttl) NoOptions) >>= (pure <<< next)
 
-interpret _ (GetCache cacheConn key next) = (R.lift $ S.lift $ E.lift $ getKey cacheConn key) >>= (pure <<< next)
+interpret _ (GetCache cacheConn key next) = (R.lift $ S.lift $ E.lift $ get cacheConn key) >>= (pure <<< next)
 
 interpret _ (KeyExistsCache cacheConn key next) = (R.lift $ S.lift $ E.lift $ exists cacheConn key) >>= (pure <<< next)
 
-interpret _ (DelCache cacheConn key next) = (R.lift $ S.lift $ E.lift $ delKey cacheConn key) >>= (pure <<< next)
+interpret _ (DelCache cacheConn key next) = (R.lift $ S.lift $ E.lift $ del cacheConn (NEArray.singleton key)) >>= (pure <<< next)
 
 interpret _ (Expire cacheConn key ttl next) = (R.lift $ S.lift $ E.lift $ expire cacheConn key ttl) >>= (pure <<< next)
-    
-interpret _ (Incr cacheConn key next) = (R.lift $ S.lift $ E.lift $ incr cacheConn key) >>= (pure <<< next) 
 
-interpret _ (SetHash cacheConn key field value next) = (R.lift $ S.lift $ E.lift $ setHash cacheConn key field value) >>= (pure <<< next) 
+interpret _ (Incr cacheConn key next) = (R.lift $ S.lift $ E.lift $ incr cacheConn key) >>= (pure <<< next)
 
-interpret _ (GetHashKey cacheConn key field next) = (R.lift $ S.lift $ E.lift $ getHashKey cacheConn key field) >>= (pure <<< next) 
+interpret _ (SetHash cacheConn key field value next) = (R.lift $ S.lift $ E.lift $ hset cacheConn key field value) >>= (pure <<< next)
 
-interpret _ (SetWithOptions cacheConn arr next) = (R.lift $ S.lift $ E.lift $ set cacheConn arr) >>= (pure <<< next) 
+interpret _ (GetHashKey cacheConn key field next) = (R.lift $ S.lift $ E.lift $ hget cacheConn key field) >>= (pure <<< next)
 
-interpret _ (PublishToChannel cacheConn channel message next) = (R.lift $ S.lift $ E.lift $ publishToChannel cacheConn channel message) >>= (pure <<< next) 
+interpret _ (PublishToChannel cacheConn channel message next) = (R.lift $ S.lift $ E.lift $ publish cacheConn channel message) >>= (pure <<< next)
 
-interpret _ (Subscribe cacheConn channel next) = (R.lift $ S.lift $ E.lift $ subscribe cacheConn channel) >>= (pure <<< next) 
+interpret _ (Subscribe cacheConn channel next) = (R.lift $ S.lift $ E.lift $ subscribe cacheConn (NEArray.singleton channel)) >>= (pure <<< next)
 
-interpret _ (SetMessageHandler cacheConn f next) = (R.lift $ S.lift $ E.lift $ setMessageHandler cacheConn f) >>= (pure <<< next) 
+interpret _ (SetMessageHandler cacheConn f next) = (R.lift $ S.lift $ E.lift $ liftEff $ setMessageHandler cacheConn f) >>= (pure <<< next)
 
 interpret _ (Enqueue cacheConn listName value next) = (R.lift $ S.lift $ E.lift $ void <$> rpush cacheConn listName value) >>= (pure <<< next)
 
@@ -113,37 +116,35 @@ interpret _ (Dequeue cacheConn listName next) = (R.lift $ S.lift $ E.lift $ lpop
 
 interpret _ (GetQueueIdx cacheConn listName index next) = (R.lift $ S.lift $ E.lift $ lindex cacheConn listName index) >>= (pure <<< next)
 
-interpret _ (GetMulti cacheConn next) = (R.lift $ S.lift $ E.lift $ getMulti cacheConn) >>= (pure <<< next)
+interpret _ (GetMulti cacheConn next) = (R.lift $ S.lift $ E.lift $ liftEff $ newMulti cacheConn) >>= (pure <<< next)
 
-interpret _ (SetCacheInMulti key val multi next) = (R.lift <<< S.lift <<< E.lift <<< setKeyMulti key val $ multi ) >>= (pure <<< next)
+interpret _ (SetCacheInMulti key val multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< setMulti key val Nothing NoOptions $ multi ) >>= (pure <<< next)
 
 interpret _ (GetCacheInMulti key multi next) = (R.lift <<< S.lift <<< E.lift <<< pure <<< next $ multi)
 
-interpret _ (DelCacheInMulti key multi next) = (R.lift <<< S.lift <<< E.lift <<< getKeyMulti key$ multi) >>= (pure <<< next )
+interpret _ (DelCacheInMulti key multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< getMulti key $ multi) >>= (pure <<< next )
 
-interpret _ (SetCacheWithExpiryInMulti key val ttl multi next) = (R.lift <<< S.lift <<< E.lift <<< setexKeyMulti key val ttl $ multi )>>= (pure <<< next )
+interpret _ (SetCacheWithExpiryInMulti key val ttl multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< setMulti key val (Just ttl) NoOptions $ multi )>>= (pure <<< next )
 
-interpret _ (ExpireInMulti key ttl multi next) = (R.lift <<< S.lift <<< E.lift <<< expireMulti key ttl $ multi) >>= (pure <<< next)
+interpret _ (ExpireInMulti key ttl multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< expireMulti key ttl $ multi) >>= (pure <<< next)
 
-interpret _ (IncrInMulti key multi next) = (R.lift <<< S.lift <<< E.lift <<< incrMulti key $ multi) >>= (pure <<< next)
+interpret _ (IncrInMulti key multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< incrMulti key $ multi) >>= (pure <<< next)
 
-interpret _ (SetHashInMulti key field value multi next) = (R.lift <<< S.lift <<< E.lift <<< setHashMulti key field value $ multi) >>= (pure <<< next )
+interpret _ (SetHashInMulti key field value multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< hsetMulti key field value $ multi) >>= (pure <<< next )
 
-interpret _ (GetHashInMulti key value multi next) = (R.lift <<< S.lift <<< E.lift <<< getHashKeyMulti key value $ multi) >>= (pure <<< next )
+interpret _ (GetHashInMulti key value multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< hgetMulti key value $ multi) >>= (pure <<< next )
 
-interpret _ (SetWithOptionsInMulti key multi next) = (R.lift <<< S.lift <<< E.lift <<< setMulti key $ multi) >>= (pure <<< next) 
+interpret _ (PublishToChannelInMulti channel message multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< publishMulti channel message $ multi) >>= (pure <<< next)
 
-interpret _ (PublishToChannelInMulti channel message multi next) = (R.lift <<< S.lift <<< E.lift <<< publishToChannelMulti channel message $ multi) >>= (pure <<< next) 
+interpret _ (SubscribeInMulti channel multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< subscribeMulti channel $ multi) >>= (pure <<< next)
 
-interpret _ (SubscribeInMulti channel multi next) = (R.lift <<< S.lift <<< E.lift <<< subscribeMulti channel $ multi) >>= (pure <<< next)
+interpret _ (EnqueueInMulti listName val multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< rpushMulti listName val $ multi) >>= (pure <<< next)
 
-interpret _ (EnqueueInMulti listName val multi next) = (R.lift <<< S.lift <<< E.lift <<< rpushMulti listName val $ multi) >>= (pure <<< next)
+interpret _ (DequeueInMulti listName multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< lpopMulti listName $ multi) >>= (pure <<< next)
 
-interpret _ (DequeueInMulti listName multi next) = (R.lift <<< S.lift <<< E.lift <<< lpopMulti listName $ multi) >>= (pure <<< next)
+interpret _ (GetQueueIdxInMulti listName index multi next) = (R.lift <<< S.lift <<< E.lift <<< liftEff <<< lindexMulti listName index $ multi) >>= (pure <<< next)
 
-interpret _ (GetQueueIdxInMulti listName index multi next) = (R.lift <<< S.lift <<< E.lift <<< lindexMulti listName index $ multi) >>= (pure <<< next)
-
-interpret _ (Exec multi next) = (R.lift <<< S.lift <<< E.lift <<< exec $ multi) >>= (pure <<< next)
+interpret _ (Exec multi next) = (R.lift <<< S.lift <<< E.lift <<< execMulti $ multi) >>= (pure <<< next)
 
 interpret (BackendRuntime a connections c) (GetCacheConn cacheName next) = do
   maybeCache <- pure $ lookup cacheName connections
@@ -170,7 +171,7 @@ interpret ((BackendRuntime a connections c)) (GetDBConn dbName next) = do
     Just (Sequelize db) -> (pure <<< next) db
     Just _ -> interpret (BackendRuntime a connections c) (ThrowException "No DB found" next)
     Nothing -> interpret (BackendRuntime a connections c) (ThrowException "No DB found" next)
-  
+
 
 interpret (BackendRuntime apiRunner _ _) (CallAPI apiInteractionF nextF) = do
   R.lift $ S.lift $ E.lift $ runAPIInteraction apiRunner apiInteractionF

--- a/src/Presto/Backend/SystemCommands.js
+++ b/src/Presto/Backend/SystemCommands.js
@@ -25,19 +25,21 @@
 
 var exec = require("child_process").exec;
 
-exports.runSysCmdImpl = function(err,sc,cmd) {
-    return function() {
-        var pid = exec(cmd,function(e,stdout,stderr) {
+exports.runSysCmdImpl = function(cmd) {
+    return function(err, sc) {
+        var pid = exec(cmd, function(e, stdout, stderr) {
             if (e instanceof Error) {
                 console.error(e);
-                err(e)();
-                return;
+                err(e);
+            } else if (typeof(stderr) == "undefined" && stderr != "") {
+                err(new Error(stderr));
+            } else {
+              sc(stdout);
             }
-            if(typeof(stderr)=="undefined" && stderr!="") {
-                err(new Error(stderr))();
-                return;
-            }
-            sc(stdout)();
         });
+
+        return function(cancelErr, onCancelErr, onCancelSc) {
+            // FIXME: can we stop the child process?
+        };
     };
 };

--- a/src/Presto/Backend/SystemCommands.purs
+++ b/src/Presto/Backend/SystemCommands.purs
@@ -22,14 +22,11 @@
 module Presto.Backend.SystemCommands where
 
 import Prelude
-import Data.Function.Uncurried (Fn3)
-import Control.Monad.Eff.Exception (Error)
-import Control.Monad.Eff (Eff)
-import Control.Monad.Aff (makeAff, Aff)
-import Data.Function.Uncurried (runFn3)
 
-foreign import runSysCmdImpl :: forall a e. Fn3 (Error -> Eff e Unit) (a -> Eff e Unit) String (Eff e Unit)
+import Control.Monad.Aff (Aff)
+import Control.Monad.Aff.Compat (EffFnAff, fromEffFnAff)
+
+foreign import runSysCmdImpl :: forall e. String -> EffFnAff e String
 
 runSysCmd :: forall eff. String -> Aff eff String
-runSysCmd cmd = do
-	makeAff $ (\err sc -> runFn3 runSysCmdImpl err sc cmd)
+runSysCmd = fromEffFnAff <<< runSysCmdImpl


### PR DESCRIPTION
purescript-redis functionality has been refactored and cleaned up. This
updates dependencies so purescript-aff 4.0.x (which is a dependency
after the cleanup) can be pulled in, and then updates purescript-redis
usage to properly compile.