### PR TITLE
Update purescript-redis to the correct commit id

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "purescript-sequelize": "https://github.com/juspay/purescript-sequelize.git#cfc0c9245322520115eca7b2c1fa0d6bbcebf315",
     "purescript-body-parser": "https://github.com/juspay/purescript-body-parser.git#0.1.0",
     "purescript-uuid": "^4.0.0",
-    "purescript-redis": "https://github.com/juspay/purescript-redis.git#e7ee80d99751588f74531802acd724d68bb5d1af",
+    "purescript-redis": "https://github.com/juspay/purescript-redis.git#3c822ea01ed5f7a43cb2ed707ab6747a07865630",
     "purescript-now": "3.0.0",
     "purescript-node-fs": "^4.0.0",
     "purescript-node-process": "^5.0.0"

--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -23,7 +23,7 @@ module Presto.Backend.Flow where
 
 import Prelude
 
-import Cache (CacheConn)
+import Cache (SimpleConn)
 import Cache.Multi (Multi)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (Error)
@@ -60,25 +60,25 @@ data BackendFlowCommands next st rt s =
     | Update (Either Error (Array s)) (Either Error (Array s) -> next)
     | Delete (Either Error Int) (Either Error Int -> next)
     | GetDBConn String (Conn -> next)
-    | GetCacheConn String (CacheConn -> next)
+    | GetCacheConn String (SimpleConn -> next)
     | Log String s next
-    | SetCache CacheConn String String (Either Error Unit -> next)
-    | SetCacheWithExpiry CacheConn String String Milliseconds (Either Error Unit -> next)
-    | GetCache CacheConn String (Either Error (Maybe String) -> next)
-    | KeyExistsCache CacheConn String (Either Error Boolean -> next)
-    | DelCache CacheConn String (Either Error Int -> next)
-    | Enqueue CacheConn String String (Either Error Unit -> next)
-    | Dequeue CacheConn String (Either Error (Maybe String) -> next)
-    | GetQueueIdx CacheConn String Int (Either Error (Maybe String) -> next)
+    | SetCache SimpleConn String String (Either Error Unit -> next)
+    | SetCacheWithExpiry SimpleConn String String Milliseconds (Either Error Unit -> next)
+    | GetCache SimpleConn String (Either Error (Maybe String) -> next)
+    | KeyExistsCache SimpleConn String (Either Error Boolean -> next)
+    | DelCache SimpleConn String (Either Error Int -> next)
+    | Enqueue SimpleConn String String (Either Error Unit -> next)
+    | Dequeue SimpleConn String (Either Error (Maybe String) -> next)
+    | GetQueueIdx SimpleConn String Int (Either Error (Maybe String) -> next)
     | Fork (BackendFlow st rt s) (Unit -> next)
-    | Expire CacheConn String Seconds (Either Error Boolean -> next)
-    | Incr CacheConn String (Either Error Int -> next)
-    | SetHash CacheConn String String String (Either Error Boolean -> next)
-    | GetHashKey CacheConn String String (Either Error (Maybe String) -> next)
-    | PublishToChannel CacheConn String String (Either Error Int -> next)
-    | Subscribe CacheConn String (Either Error Unit -> next)
-    | SetMessageHandler CacheConn (forall eff. (String -> String -> Eff eff Unit)) (Unit -> next)
-    | GetMulti CacheConn (Multi -> next)
+    | Expire SimpleConn String Seconds (Either Error Boolean -> next)
+    | Incr SimpleConn String (Either Error Int -> next)
+    | SetHash SimpleConn String String String (Either Error Boolean -> next)
+    | GetHashKey SimpleConn String String (Either Error (Maybe String) -> next)
+    | PublishToChannel SimpleConn String String (Either Error Int -> next)
+    | Subscribe SimpleConn String (Either Error Unit -> next)
+    | SetMessageHandler SimpleConn (forall eff. (String -> String -> Eff eff Unit)) (Unit -> next)
+    | GetMulti SimpleConn (Multi -> next)
     | SetCacheInMulti String String Multi (Multi -> next)
     | GetCacheInMulti String Multi (Multi -> next)
     | DelCacheInMulti String Multi (Multi -> next)
@@ -184,7 +184,7 @@ getDBConn :: forall st rt. String -> BackendFlow st rt Conn
 getDBConn dbName = do
   wrap $ GetDBConn dbName id
 
-getCacheConn :: forall st rt. String -> BackendFlow st rt CacheConn
+getCacheConn :: forall st rt. String -> BackendFlow st rt SimpleConn
 getCacheConn dbName = wrap $ GetCacheConn dbName id
 
 newMulti :: forall st rt. String -> BackendFlow st rt Multi

--- a/src/Presto/Backend/Language/Interpreter.purs
+++ b/src/Presto/Backend/Language/Interpreter.purs
@@ -23,7 +23,7 @@ module Presto.Backend.Interpreter where
 
 import Prelude
 
-import Cache (CacheConn, SetOptions(..), del, exists, expire, get, incr, publish, set, setMessageHandler, subscribe)
+import Cache (SetOptions(..), SimpleConn, del, exists, expire, get, incr, publish, set, setMessageHandler, subscribe)
 import Cache.Hash (hget, hset)
 import Cache.List (lindex, lpop, rpush)
 import Cache.Multi (execMulti, expireMulti, getMulti, hgetMulti, hsetMulti, incrMulti, lindexMulti, lpopMulti, newMulti, publishMulti, rpushMulti, setMulti, subscribeMulti)
@@ -51,7 +51,7 @@ type InterpreterMT rt st err eff a = R.ReaderT rt (S.StateT st (E.ExceptT err (B
 
 type Cache = {
     name :: String
-  , connection :: CacheConn
+  , connection :: SimpleConn
 }
 
 type DB = {
@@ -61,7 +61,7 @@ type DB = {
 
 type LogRunner = forall e a. String -> a -> Aff e Unit
 
-data Connection = Sequelize Conn | Redis CacheConn
+data Connection = Sequelize Conn | Redis SimpleConn
 
 data BackendRuntime = BackendRuntime APIRunner (StrMap Connection) LogRunner
 


### PR DESCRIPTION
The previously used commit id was stale. The update requires that we
move all CacheConn references to SimpleConn. This does raise the
question of how we might want to do Cluster support as that introduces
the need to express the connection type as a typeclass (CacheConn a),
but that might require dramatic changes, or dropping Redis support
entirely from Presto Backend.