### PR TITLE
Update purescript-redis after set API change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "purescript-sequelize": "https://github.com/juspay/purescript-sequelize.git#cfc0c9245322520115eca7b2c1fa0d6bbcebf315",
     "purescript-body-parser": "https://github.com/juspay/purescript-body-parser.git#0.1.0",
     "purescript-uuid": "^4.0.0",
-    "purescript-redis": "https://github.com/juspay/purescript-redis.git#042631881afc9898fdd395eed0992c0e07966376",
+    "purescript-redis": "https://github.com/juspay/purescript-redis.git#7fc7821c6ad3b3b3a83dc9aef08e3a1b8d081ebb",
     "purescript-now": "3.0.0",
     "purescript-node-fs": "^4.0.0",
     "purescript-node-process": "^5.0.0"

--- a/src/Presto/Backend/Language/Interpreter.purs
+++ b/src/Presto/Backend/Language/Interpreter.purs
@@ -86,9 +86,9 @@ interpret _ (ThrowException errorMessage next) = R.lift S.get >>= (R.lift <<< S.
 
 interpret _ (DoAff aff nextF) = (R.lift $ S.lift $ E.lift aff) >>= (pure <<< nextF)
 
-interpret _ (SetCache cacheConn key value next) = (R.lift $ S.lift $ E.lift $ set cacheConn key value Nothing NoOptions) >>= (pure <<< next)
+interpret _ (SetCache cacheConn key value next) = (R.lift $ S.lift $ E.lift $ void <$> set cacheConn key value Nothing NoOptions) >>= (pure <<< next)
 
-interpret _ (SetCacheWithExpiry cacheConn key value ttl next) = (R.lift $ S.lift $ E.lift $ set cacheConn key value (Just ttl) NoOptions) >>= (pure <<< next)
+interpret _ (SetCacheWithExpiry cacheConn key value ttl next) = (R.lift $ S.lift $ E.lift $ void <$> set cacheConn key value (Just ttl) NoOptions) >>= (pure <<< next)
 
 interpret _ (GetCache cacheConn key next) = (R.lift $ S.lift $ E.lift $ get cacheConn key) >>= (pure <<< next)
 


### PR DESCRIPTION
set now returns a Boolean which is only meaningful for the EX/NX cases.
Since we don't use those, we just discard the return value.