### PR TITLE
UpdateDash function returns only affectedRowsCount

### DIFF
--- a/src/Presto/Backend/DB/DB.purs
+++ b/src/Presto/Backend/DB/DB.purs
@@ -139,15 +139,14 @@ update conn updateValues whereClause = do
                 Left err -> pure <<< Left $ err
         Left err -> pure $ Left $ error $ show err
 
-update' :: forall a e . Model a => Conn -> Options a -> Options a -> Aff (sequelize :: SEQUELIZE | e) (Either Error (Array (Instance a)))
+update' :: forall a e . Model a => Conn -> Options a -> Options a -> Aff (sequelize :: SEQUELIZE | e) (Either Error Int)
 update' conn updateValues whereClause = do
     model <- getModelByName conn :: (Aff (sequelize :: SEQUELIZE | e) (Either Error (ModelOf a)))
     case model of
         Right m -> do
             val <- attempt $ updateModel m updateValues whereClause
             case val of
-                Right {affectedRows : Just x} -> pure <<< Right $ x
-                Right _  -> pure <<< Right $ mempty
+                Right {affectedCount} -> pure <<< Right $ affectedCount
                 Left err -> pure <<< Left $ error $ show err
         Left err -> pure $ Left $ error $ show err
 

--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -35,7 +35,7 @@ import Data.Foreign.Class (class Decode, class Encode)
 import Data.Maybe (Maybe(..))
 import Data.Options (Options)
 import Data.Time.Duration (Milliseconds, Seconds)
-import Presto.Backend.DB (findOne, findAll, create, createWithOpts, query, update, delete, update') as DB
+import Presto.Backend.DB (findOne, findAll, create, createWithOpts, query, update, delete) as DB
 import Presto.Backend.Types (BackendAff)
 import Presto.Core.Types.API (class RestEndpoint, Headers)
 import Presto.Core.Types.Language.APIInteract (apiInteract)
@@ -171,13 +171,6 @@ update dbName updateValues whereClause = do
   conn <- getDBConn dbName
   model <- doAff do
         DB.update conn updateValues whereClause
-  wrap $ Update model id
-
-update' :: forall model st rt. Model model => String -> Options model -> Options model -> BackendFlow st rt (Either Error (Array (Instance model)))
-update' dbName updateValues whereClause = do
-  conn <- getDBConn dbName
-  model <- doAff do
-        DB.update' conn updateValues whereClause
   wrap $ Update model id
 
 delete :: forall model st rt. Model model => String -> Options model -> BackendFlow st rt (Either Error Int)


### PR DESCRIPTION
Before: It was trying to return an empty array in case of successful update in case of MySql as MySql doesn't return the array of objects that were affected.

After: It returns a count of rows updated as it is compatible with Postgres and MySql as well.