### PR TITLE
Added ParSequence for backendflow

### DIFF
--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -23,15 +23,13 @@ module Presto.Backend.Flow where
 
 import Prelude
 
-import Cache.Types (EntryID(..), Item(..))
+import Cache.Types (EntryID, Item)
 import Control.Monad.Aff (Aff)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Except (runExcept)
 import Control.Monad.Free (Free, liftF)
-import Control.Monad (when, unless)
 import Data.Either (Either(..))
-import Data.String (null)
 import Data.Exists (Exists, mkExists)
 import Data.Foreign (Foreign, toForeign)
 import Data.Foreign.Class (class Decode, class Encode, encode)
@@ -40,7 +38,9 @@ import Data.Maybe (Maybe(Just, Nothing))
 import Data.Newtype (class Newtype)
 import Data.Options (Options)
 import Data.Options (options) as Opt
+import Data.String (null)
 import Data.Time.Duration (Milliseconds, Seconds)
+import Data.Tuple (Tuple)
 import Presto.Backend.APIInteract (apiInteract)
 import Presto.Backend.DB.Mock.Actions (mkCreate, mkCreateWithOpts, mkDelete, mkFindAll, mkFindOne, mkQuery, mkUpdate) as SqlDBMock
 import Presto.Backend.DB.Mock.Types (DBActionDict, mkDbActionDict) as SqlDBMock
@@ -49,16 +49,16 @@ import Presto.Backend.KVDB.Mock.Types as KVDBMock
 import Presto.Backend.Language.KVDB (KVDB, delCache, delCacheInMulti, dequeue, dequeueInMulti, enqueue, enqueueInMulti, execMulti, expire, expireInMulti, getCache, getCacheInMulti, getHashKey, getHashKeyInMulti, getQueueIdx, getQueueIdxInMulti, incr, incrInMulti, keyExistsCache, newMulti, publishToChannel, publishToChannelInMulti, setCache, setCacheInMulti, setHash, setHashInMulti, setMessageHandler, subscribe, subscribeToMulti, addInMulti) as KVDB
 import Presto.Backend.Language.Types.DB (DBError, KVDBConn, MockedKVDBConn, MockedSqlConn, SqlConn, fromDBMaybeResult, toDBMaybeResult)
 import Presto.Backend.Language.Types.EitherEx (EitherEx, fromCustomEitherEx, fromCustomEitherExF, toCustomEitherEx, toCustomEitherExF)
-import Presto.Backend.Language.Types.MaybeEx (MaybeEx)
 import Presto.Backend.Language.Types.KVDB (Multi)
 import Presto.Backend.Language.Types.KVDB (getKVDBName) as KVDB
+import Presto.Backend.Language.Types.MaybeEx (MaybeEx)
 import Presto.Backend.Language.Types.UnitEx (UnitEx, fromUnitEx, toUnitEx)
 import Presto.Backend.Playback.Entries (CallAPIEntry, GenerateGUIDEntry, DoAffEntry, ForkFlowEntry, GetDBConnEntry, GetKVDBConnEntry, LogEntry, GetOptionEntry, RunDBEntry, RunKVDBEitherEntry, RunKVDBSimpleEntry, RunSysCmdEntry, SetOptionEntry, mkCallAPIEntry, mkDoAffEntry, mkForkFlowEntry, mkGetDBConnEntry, mkGetKVDBConnEntry, mkLogEntry, mkGetOptionEntry, mkRunDBEntry, mkRunKVDBEitherEntry, mkRunKVDBSimpleEntry, mkRunSysCmdEntry, mkGenerateGUIDEntry, mkSetOptionEntry) as Playback
 import Presto.Backend.Playback.Types (RRItemDict, mkEntryDict) as Playback
+import Presto.Backend.Runtime.Common (jsonStringify)
 import Presto.Backend.Types (BackendAff)
 import Presto.Backend.Types.API (class RestEndpoint, Headers, ErrorResponse, APIResult, makeRequest)
 import Presto.Backend.Types.Options (class OptionEntity)
-import Presto.Backend.Runtime.Common (jsonStringify)
 import Presto.Core.Types.Language.Interaction (Interaction)
 import Sequelize.Class (class Model)
 import Sequelize.Types (Conn, SEQUELIZE)
@@ -95,6 +95,9 @@ data BackendFlowCommands next st rt s
     | RunSysCmd String
         (Playback.RRItemDict Playback.RunSysCmdEntry String)
         (String -> next)
+
+    | ParSequence (Array (BackendFlow st rt s))
+        (Array (Either (Tuple Error st) s) → next)
 
     | ThrowException String
 
@@ -259,6 +262,9 @@ forkFlow' description flow = do
 
 forkFlow :: forall st rt a. BackendFlow st rt a -> BackendFlow st rt Unit
 forkFlow = forkFlow' ""
+
+parSequence :: ∀ st rt a. Array (BackendFlow st rt a) → BackendFlow st rt (Array (Either (Tuple Error st) a))
+parSequence tbf = wrap $ ParSequence tbf id
 
 runSysCmd :: forall st rt. String -> BackendFlow st rt String
 runSysCmd cmd =

--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -40,7 +40,6 @@ import Data.Options (Options)
 import Data.Options (options) as Opt
 import Data.String (null)
 import Data.Time.Duration (Milliseconds, Seconds)
-import Data.Tuple (Tuple)
 import Presto.Backend.APIInteract (apiInteract)
 import Presto.Backend.DB.Mock.Actions (mkCreate, mkCreateWithOpts, mkDelete, mkFindAll, mkFindOne, mkQuery, mkUpdate) as SqlDBMock
 import Presto.Backend.DB.Mock.Types (DBActionDict, mkDbActionDict) as SqlDBMock
@@ -97,7 +96,7 @@ data BackendFlowCommands next st rt s
         (String -> next)
 
     | ParSequence (Array (BackendFlow st rt s))
-        (Array (Either (Tuple Error st) s) → next)
+        (Array (Either Error s) → next)
 
     | ThrowException String
 
@@ -263,7 +262,7 @@ forkFlow' description flow = do
 forkFlow :: forall st rt a. BackendFlow st rt a -> BackendFlow st rt Unit
 forkFlow = forkFlow' ""
 
-parSequence :: ∀ st rt a. Array (BackendFlow st rt a) → BackendFlow st rt (Array (Either (Tuple Error st) a))
+parSequence :: ∀ st rt a. Array (BackendFlow st rt a) → BackendFlow st rt (Array (Either Error a))
 parSequence tbf = wrap $ ParSequence tbf id
 
 runSysCmd :: forall st rt. String -> BackendFlow st rt String

--- a/src/Presto/Backend/Runtime/Interpreter.purs
+++ b/src/Presto/Backend/Runtime/Interpreter.purs
@@ -27,34 +27,36 @@ module Presto.Backend.Runtime.Interpreter
 import Prelude
 
 import Control.Monad.Aff (forkAff)
-import Control.Monad.Aff.AVar (AVAR, AVar, makeVar, readVar, takeVar, putVar)
+import Control.Monad.Aff.AVar (makeVar, putVar, readVar, takeVar)
 import Control.Monad.Aff.Class (liftAff)
-import Control.Monad.Eff.Exception (Error, throwException, error)
 import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Except.Trans (runExceptT) as E
 import Control.Monad.Free (foldFree)
 import Control.Monad.Reader.Trans (ask, lift, runReaderT) as R
 import Control.Monad.State.Trans (get, modify, put, runStateT) as S
+import Control.Parallel (parSequence)
+import Data.Array (foldl, (:))
 import Data.Exists (runExists)
-import Data.Tuple (Tuple)
-import Data.StrMap as StrMap
-import Data.UUID (genUUID)
 import Data.Maybe (Maybe(..))
+import Data.StrMap as StrMap
+import Data.Tuple (Tuple, fst)
+import Data.UUID (genUUID)
+import Presto.Backend.DB.Mock.Types (DBActionDict)
 import Presto.Backend.Flow (BackendFlow, BackendFlowCommands(..), BackendFlowCommandsWrapper, BackendFlowWrapper(..))
-import Presto.Backend.SystemCommands (runSysCmd)
-import Presto.Backend.Language.Types.EitherEx (fromEitherEx, toEitherEx)
-import Presto.Backend.Language.Types.MaybeEx (fromMaybeEx, toMaybeEx)
-import Presto.Backend.Language.Types.UnitEx (UnitEx(..), fromUnitEx)
 import Presto.Backend.Language.Types.DB (SqlConn(..))
+import Presto.Backend.Language.Types.EitherEx (fromEitherEx)
+import Presto.Backend.Language.Types.MaybeEx (fromMaybeEx, toMaybeEx)
+import Presto.Backend.Language.Types.UnitEx (UnitEx(UnitEx))
+import Presto.Backend.Playback.Entries (mkThrowExceptionEntry)
+import Presto.Backend.Playback.Machine.Classless (withRunModeClassless)
+import Presto.Backend.Playback.Types (PlaybackError(PlaybackError), PlaybackErrorType(ForkedFlowRecordingsMissed), PlayerRuntime, RecorderRuntime, mkEntryDict)
+import Presto.Backend.Runtime.API (runAPIInteraction)
 import Presto.Backend.Runtime.Common (lift3, throwException', getDBConn', getKVDBConn')
+import Presto.Backend.Runtime.KVDBInterpreter (runKVDB)
 import Presto.Backend.Runtime.Types (InterpreterMT, InterpreterMT', BackendRuntime(..), RunningMode(..))
 import Presto.Backend.Runtime.Types as X
-import Presto.Backend.Playback.Machine.Classless (withRunModeClassless)
-import Presto.Backend.Playback.Entries (mkThrowExceptionEntry)
-import Presto.Backend.Playback.Types (RecorderRuntime(..), PlayerRuntime(..), PlaybackError(..), PlaybackErrorType(..), mkEntryDict)
-import Presto.Backend.Runtime.API (runAPIInteraction)
-import Presto.Backend.Runtime.KVDBInterpreter (runKVDB)
-import Presto.Backend.DB.Mock.Types (DBActionDict)
+import Presto.Backend.SystemCommands (runSysCmd)
 
 forkF :: forall eff rt st a. BackendRuntime -> BackendFlow st rt a -> InterpreterMT rt st (Tuple Error st) eff Unit
 forkF brt flow = do
@@ -195,6 +197,13 @@ interpret brt@(BackendRuntime rt) (Fork flow flowGUID rrItemDict next) = do
         Just forkedBrt -> forkF forkedBrt flow *> pure UnitEx)
 
   pure $ next UnitEx
+
+interpret brt@(BackendRuntime rt) (ParSequence aflow next) = do
+  st ← R.lift S.get
+  rt ← R.ask
+  (next <<< map (map fst)) <$> (lift3 $ parSequence $ foldl (flowToAff st rt) [] aflow)
+  where
+      flowToAff st rt acc flow = E.runExceptT (S.runStateT (R.runReaderT (runBackend brt flow) rt) st) : acc
 
 interpret brt (RunSysCmd cmd rrItemDict next) = do
   res <- withRunModeClassless brt rrItemDict

--- a/src/Presto/Backend/Runtime/Interpreter.purs
+++ b/src/Presto/Backend/Runtime/Interpreter.purs
@@ -37,6 +37,7 @@ import Control.Monad.Reader.Trans (ask, lift, runReaderT) as R
 import Control.Monad.State.Trans (get, modify, put, runStateT) as S
 import Control.Parallel (parSequence)
 import Data.Array (foldl, (:))
+import Data.Either (Either(..), either)
 import Data.Exists (runExists)
 import Data.Maybe (Maybe(..))
 import Data.StrMap as StrMap
@@ -201,7 +202,7 @@ interpret brt@(BackendRuntime rt) (Fork flow flowGUID rrItemDict next) = do
 interpret brt@(BackendRuntime rt) (ParSequence aflow next) = do
   st ← R.lift S.get
   rt ← R.ask
-  (next <<< map (map fst)) <$> (lift3 $ parSequence $ foldl (flowToAff st rt) [] aflow)
+  (next <<< map (either (Left <<< fst) (Right <<< fst))) <$> (lift3 $ parSequence $ foldl (flowToAff st rt) [] aflow)
   where
       flowToAff st rt acc flow = E.runExceptT (S.runStateT (R.runReaderT (runBackend brt flow) rt) st) : acc
 


### PR DESCRIPTION
We need to run an Array of Backendflow in parallel, we can't actually do a parSequence or parTraverse on Backendflow as it requires instance on PARALLEL, to create an intsance on parallel we need backend runner, it won't available outside. To overcome this we added parSequence in DSL so that it internally refers to the parallel instance underlying Aff