### PR TITLE
Changed Response of a to Response.

### DIFF
--- a/src/Presto/Backend/Language/APIInteract.purs
+++ b/src/Presto/Backend/Language/APIInteract.purs
@@ -49,7 +49,7 @@ apiInteract a headers = do
                        Left y -> Response
                                     { code : 0
                                     , status : ""
-                                    , response : ErrorPayload
+                                    , response : encode $ ErrorPayload
                                                     { error: true
                                                     , errorMessage: show x <> "\n" <> show y
                                                     , userMessage: "Unknown error"

--- a/src/Presto/Backend/Language/Types/API.purs
+++ b/src/Presto/Backend/Language/Types/API.purs
@@ -46,7 +46,7 @@ import Prelude
 
 import Control.Monad.Aff (Aff)
 import Data.Either (Either)
-import Data.Foreign (F)
+import Data.Foreign (F, Foreign)
 import Data.Foreign.Class (class Decode, class Encode)
 import Data.Foreign.Generic.Class (class GenericDecode, class GenericEncode)
 import Data.Generic.Rep (class Generic)
@@ -103,13 +103,13 @@ newtype Request = Request
   , headers :: Headers
   }
 
-newtype Response a = Response
+newtype Response = Response
   { code :: Int
   , status :: String
-  , response :: a
+  , response :: Foreign
   }
 
-responsePayload :: forall a. Response a -> a
+responsePayload :: Response -> Foreign
 responsePayload (Response r) = r.response
 
 newtype ErrorPayload = ErrorPayload
@@ -118,7 +118,7 @@ newtype ErrorPayload = ErrorPayload
   , userMessage :: String
   }
 
-type ErrorResponse = Response ErrorPayload
+type ErrorResponse = Response
 
 derive instance genericMethod :: Generic Method _
 instance encodeMethod :: Encode Method where
@@ -155,14 +155,11 @@ instance decodeErrorPayload :: Decode ErrorPayload where
 instance showErrorPayload :: Show ErrorPayload where
   show (ErrorPayload payload) = payload.userMessage
 
-derive instance genericResponse :: Generic (Response a) _
-derive instance eqResponse :: Eq a => Eq (Response a)
-instance decodeResponseG :: Decode a => Decode (Response a) where
+derive instance genericResponse :: Generic Response _
+instance decodeResponseG :: Decode Response where
   decode = defaultDecode
-instance encodeResponseG :: Encode a => Encode (Response a) where
+instance encodeResponseG :: Encode Response where
   encode = defaultEncode
-instance showResponse :: Show a => Show (Response a) where
-  show (Response r) = show r.code <> "_" <> r.status <> "_" <> (show r.response)
 
 derive instance genericGetReqBody :: Generic GetReqBody _
 instance decodeGetReqBody :: Decode GetReqBody where decode = defaultDecode

--- a/src/Presto/Backend/Playback/Entries.purs
+++ b/src/Presto/Backend/Playback/Entries.purs
@@ -22,28 +22,19 @@
 module Presto.Backend.Playback.Entries where
 
 import Prelude
-import Presto.Backend.Playback.Types
-import Data.Either (Either(..), note, hush, isLeft)
+import Presto.Backend.Playback.Types (class MockedResult, class RRItem, RecordingEntry(..))
+import Data.Either (hush)
 import Data.Foreign.Class (class Encode, class Decode, encode, decode)
 import Data.Foreign (Foreign)
-import Data.Foreign.Generic (defaultOptions, genericDecode, genericDecodeJSON, genericEncode, genericEncodeJSON, encodeJSON, decodeJSON)
-import Data.Foreign.Generic.Class (class GenericDecode, class GenericEncode)
-import Data.Foreign.Generic.Types (Options, SumEncoding(..))
+import Data.Foreign.Generic (decodeJSON, defaultOptions, encodeJSON, genericDecode, genericEncode)
 import Data.Generic.Rep.Show as GShow
 import Data.Generic.Rep (class Generic)
-import Data.Maybe (Maybe(..), isJust)
-import Data.Newtype (class Newtype)
-import Data.Tuple (Tuple(..))
-import Presto.Backend.Runtime.Common (jsonStringify)
-import Presto.Backend.Types (BackendAff)
-import Presto.Backend.Types.API (APIResult(..), ErrorPayload, ErrorResponse, Response)
-import Presto.Backend.Types.Options (class OptionEntity)
-import Presto.Core.Utils.Encoding (defaultDecode, defaultEncode, defaultEnumDecode, defaultEnumEncode)
-import Prelude (class Eq, bind, pure, ($), (<$>), (<<<), (==))
+import Data.Maybe (Maybe(Just))
+import Presto.Backend.Types.API (ErrorResponse, Response)
 
 import Control.Monad.Except (runExcept) as E
 import Presto.Backend.Language.Types.EitherEx (EitherEx(..))
-import Presto.Backend.Language.Types.MaybeEx (MaybeEx(..))
+import Presto.Backend.Language.Types.MaybeEx (MaybeEx)
 import Presto.Backend.Language.Types.UnitEx (UnitEx(..))
 import Presto.Backend.Language.Types.DB (DBError, KVDBConn(MockedKVDB, Redis), MockedKVDBConn(MockedKVDBConn), MockedSqlConn(MockedSqlConn), SqlConn(MockedSql, Sequelize))
 
@@ -248,7 +239,7 @@ instance rrItemGetOptionEntry :: RRItem GetOptionEntry where
   getTag   _ = "GetOptionEntry"
 
 instance mockedResultGetOptionEntry :: MockedResult GetOptionEntry (MaybeEx String) where
-  parseRRItem (GetOptionEntry e) = Just e.result 
+  parseRRItem (GetOptionEntry e) = Just e.result
 
 derive instance genericGenerateGUIDEntry :: Generic GenerateGUIDEntry _
 derive instance eqGenerateGUIDEntry :: Eq GenerateGUIDEntry
@@ -323,7 +314,7 @@ instance rrItemCallAPIEntry :: RRItem CallAPIEntry where
 
 instance mockedResultCallAPIEntry
   :: Decode b
-  => MockedResult CallAPIEntry (EitherEx (Response ErrorPayload) b) where
+  => MockedResult CallAPIEntry (EitherEx Response b) where
     parseRRItem (CallAPIEntry ce) = do
       eResult <- case ce.jsonResult of
         LeftEx  errResp -> Just $ LeftEx errResp


### PR DESCRIPTION
The polymorphic type a is changed to Foreign.

Issue: The ErrorResponse type of API is a static type. (Response ErrorPayload)
But sometimes error response won't be ErrorPayload.

So changing the polymorphic a type to Foreign. Thus handling the type in the application.