### PR TITLE
Feature/generic error

### DIFF
--- a/src/Presto/Backend/Language/APIInteract.purs
+++ b/src/Presto/Backend/Language/APIInteract.purs
@@ -21,17 +21,50 @@
 
 module Presto.Backend.APIInteract
   ( apiInteract
+  , apiInteractGeneric
   ) where
-
-import Prelude (bind, pure, show, ($), (<>), (>>=))
 
 import Control.Monad.Except (runExcept)
 import Data.Either (Either(..))
+import Data.Foreign (toForeign)
 import Data.Foreign.Class (class Decode, class Encode, decode, encode)
-import Presto.Core.Types.Language.Interaction (Interaction, request)
-import Presto.Backend.Types.API (class RestEndpoint,  ErrorPayload(..), ErrorResponse, Response(..), Headers, decodeResponse, makeRequest)
+import Prelude (bind, pure, show, ($), (<>), (>>=))
 import Presto.Backend.Language.Types.EitherEx (EitherEx(..))
+import Presto.Backend.Types.API (class RestEndpoint, ErrorPayload(..), ErrorResponse, Response(..), Headers, decodeResponse, makeRequest)
+import Presto.Core.Types.Language.Interaction (Interaction, request)
 import Presto.Core.Utils.Encoding (defaultDecodeJSON)
+
+apiInteractGeneric
+  :: ∀ a b err
+   . Encode a
+   ⇒ Encode b
+   ⇒ Decode b
+   ⇒ Decode err
+   ⇒ RestEndpoint a b
+   ⇒ a
+   → Headers → Interaction (EitherEx ErrorResponse (Either (Response err) b))
+apiInteractGeneric a headers = do
+  fgnOut ← request $ encode $ makeRequest a headers
+  pure $ case runExcept $ decode fgnOut >>= decodeResponse of
+    Right resp → RightEx $ Right resp
+    Left x     →
+      case runExcept $ decode fgnOut >>= defaultDecodeJSON of
+      -- See if the server sent an error response, else create our own
+        Right e@(Response _) →
+          case runExcept $ decode $ toForeign e of
+            Right (err :: ErrorResponse)  → LeftEx err
+            Left _                        → RightEx $ Left e
+        Left y →
+          LeftEx $
+            Response
+              { code : 0
+              , status : ""
+              , response : ErrorPayload
+                              { error: true
+                              , errorMessage: show x <> "\n" <> show y
+                              , userMessage: "Unknown error"
+                              }
+              } -- Differs from core @apiInteract@ by the only thing - @Encode@ constraint for @b@.
 
 -- Interact function for API.
 -- Differs from core @apiInteract@ by the only thing - @Encode@ constraint for @b@.

--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -24,14 +24,13 @@ module Presto.Backend.Flow where
 import Prelude
 
 import Cache.Types (EntryID(..), Item(..))
+import Control.Monad (when, unless)
 import Control.Monad.Aff (Aff)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Except (runExcept)
 import Control.Monad.Free (Free, liftF)
-import Control.Monad (when, unless)
 import Data.Either (Either(..))
-import Data.String (null)
 import Data.Exists (Exists, mkExists)
 import Data.Foreign (Foreign, toForeign)
 import Data.Foreign.Class (class Decode, class Encode, encode)
@@ -40,8 +39,9 @@ import Data.Maybe (Maybe(Just, Nothing))
 import Data.Newtype (class Newtype)
 import Data.Options (Options)
 import Data.Options (options) as Opt
+import Data.String (null)
 import Data.Time.Duration (Milliseconds, Seconds)
-import Presto.Backend.APIInteract (apiInteract)
+import Presto.Backend.APIInteract (apiInteract, apiInteractGeneric)
 import Presto.Backend.DB.Mock.Actions (mkCreate, mkCreateWithOpts, mkDelete, mkFindAll, mkFindOne, mkQuery, mkUpdate) as SqlDBMock
 import Presto.Backend.DB.Mock.Types (DBActionDict, mkDbActionDict) as SqlDBMock
 import Presto.Backend.DBImpl (create, createWithOpts, delete, findAll, findOne, query, update, update') as DB
@@ -49,16 +49,16 @@ import Presto.Backend.KVDB.Mock.Types as KVDBMock
 import Presto.Backend.Language.KVDB (KVDB, delCache, delCacheInMulti, dequeue, dequeueInMulti, enqueue, enqueueInMulti, execMulti, expire, expireInMulti, getCache, getCacheInMulti, getHashKey, getHashKeyInMulti, getQueueIdx, getQueueIdxInMulti, incr, incrInMulti, keyExistsCache, newMulti, publishToChannel, publishToChannelInMulti, setCache, setCacheInMulti, setHash, setHashInMulti, setMessageHandler, subscribe, subscribeToMulti, addInMulti) as KVDB
 import Presto.Backend.Language.Types.DB (DBError, KVDBConn, MockedKVDBConn, MockedSqlConn, SqlConn, fromDBMaybeResult, toDBMaybeResult)
 import Presto.Backend.Language.Types.EitherEx (EitherEx, fromCustomEitherEx, fromCustomEitherExF, toCustomEitherEx, toCustomEitherExF)
-import Presto.Backend.Language.Types.MaybeEx (MaybeEx)
 import Presto.Backend.Language.Types.KVDB (Multi)
 import Presto.Backend.Language.Types.KVDB (getKVDBName) as KVDB
+import Presto.Backend.Language.Types.MaybeEx (MaybeEx)
 import Presto.Backend.Language.Types.UnitEx (UnitEx, fromUnitEx, toUnitEx)
-import Presto.Backend.Playback.Entries (CallAPIEntry, GenerateGUIDEntry, DoAffEntry, ForkFlowEntry, GetDBConnEntry, GetKVDBConnEntry, LogEntry, GetOptionEntry, RunDBEntry, RunKVDBEitherEntry, RunKVDBSimpleEntry, RunSysCmdEntry, SetOptionEntry, mkCallAPIEntry, mkDoAffEntry, mkForkFlowEntry, mkGetDBConnEntry, mkGetKVDBConnEntry, mkLogEntry, mkGetOptionEntry, mkRunDBEntry, mkRunKVDBEitherEntry, mkRunKVDBSimpleEntry, mkRunSysCmdEntry, mkGenerateGUIDEntry, mkSetOptionEntry) as Playback
+import Presto.Backend.Playback.Entries (CallAPIEntry, CallAPIGenericEntry(..), DoAffEntry, ForkFlowEntry, GenerateGUIDEntry, GetDBConnEntry, GetKVDBConnEntry, GetOptionEntry, LogEntry, RunDBEntry, RunKVDBEitherEntry, RunKVDBSimpleEntry, RunSysCmdEntry, SetOptionEntry, mkCallAPIEntry, mkCallAPIGenericEntry, mkDoAffEntry, mkForkFlowEntry, mkGenerateGUIDEntry, mkGetDBConnEntry, mkGetKVDBConnEntry, mkGetOptionEntry, mkLogEntry, mkRunDBEntry, mkRunKVDBEitherEntry, mkRunKVDBSimpleEntry, mkRunSysCmdEntry, mkSetOptionEntry) as Playback
 import Presto.Backend.Playback.Types (RRItemDict, mkEntryDict) as Playback
-import Presto.Backend.Types (BackendAff)
-import Presto.Backend.Types.API (class RestEndpoint, Headers, ErrorResponse, APIResult, makeRequest)
-import Presto.Backend.Types.Options (class OptionEntity)
 import Presto.Backend.Runtime.Common (jsonStringify)
+import Presto.Backend.Types (BackendAff)
+import Presto.Backend.Types.API (class RestEndpoint, APIResult, ErrorResponse, Headers, Response(..), makeRequest)
+import Presto.Backend.Types.Options (class OptionEntity)
 import Presto.Core.Types.Language.Interaction (Interaction)
 import Sequelize.Class (class Model)
 import Sequelize.Types (Conn, SEQUELIZE)
@@ -76,6 +76,10 @@ data BackendFlowCommands next st rt s
     | CallAPI (Interaction (EitherEx ErrorResponse s))
         (Playback.RRItemDict Playback.CallAPIEntry (EitherEx ErrorResponse s))
         (APIResult s -> next)
+
+    | CallAPIGeneric (Interaction (EitherEx ErrorResponse s))
+        (Playback.RRItemDict Playback.CallAPIGenericEntry (EitherEx ErrorResponse s))
+        (Either ErrorResponse s → next)
 
     | DoAff (forall eff. BackendAff eff s) (s -> next)
 
@@ -215,6 +219,22 @@ callAPI headers a = wrap $ CallAPI
   (Playback.mkEntryDict
     (encodeJSON $ makeRequest a headers)
     (Playback.mkCallAPIEntry (\_ -> encode $ makeRequest a headers)))
+  id
+
+callAPIGeneric
+  :: ∀ st rt a b err
+   . Encode a
+   ⇒ Encode b
+   ⇒ Decode b
+   ⇒ Encode err
+   ⇒ Decode err
+   ⇒ RestEndpoint a b
+   ⇒ Headers → a → BackendFlow st rt (Either ErrorResponse (Either (Response err) b))
+callAPIGeneric headers a = wrap $ CallAPIGeneric
+  (apiInteractGeneric a headers)
+  (Playback.mkEntryDict
+    (encodeJSON $ makeRequest a headers)
+    (Playback.mkCallAPIGenericEntry (\_ → encode $ makeRequest a headers)))
   id
 
 doAff :: forall st rt a. (forall eff. BackendAff eff a) -> BackendFlow st rt a

--- a/src/Presto/Backend/Runtime/Interpreter.purs
+++ b/src/Presto/Backend/Runtime/Interpreter.purs
@@ -174,6 +174,11 @@ interpret brt@(BackendRuntime rt) (CallAPI apiAct rrItemDict next) = do
     (lift3 $ runAPIInteraction rt.apiRunner apiAct)
   pure $ next $ fromEitherEx resultEx
 
+interpret brt@(BackendRuntime rt) (CallAPIGeneric apiAct rrItemDict next) = do
+  next <<< fromEitherEx
+  <$> withRunModeClassless brt rrItemDict
+        (lift3 $ runAPIInteraction rt.apiRunner apiAct)
+
 interpret _ (DoAff aff next) = next <$> lift3 aff
 
 interpret brt@(BackendRuntime rt) (DoAffRR aff rrItemDict next) = do


### PR DESCRIPTION
Added CallAPIGeneric in DSL.
Added ART support and Test for CallAPIGeneric.

Issue: The ErrorResponse type of API is a static type. (Response ErrorPayload)
But sometimes error response won't be ErrorPayload.

Now CallAPIGeneric Supports Generic Error Type. So in the application, we can specify the type for errors.
