### PR TITLE
added parSequence for backendflow

### DIFF
--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -138,6 +138,9 @@ data BackendFlowCommands next st rt s
         (Playback.RRItemDict Playback.SetOptionEntry UnitEx)
         (UnitEx -> next)
 
+    | ParSequence (Array (BackendFlow st rt s))
+        (Array (Either Error s) → next)
+
 type BackendFlowCommandsWrapper st rt s next = BackendFlowCommands next st rt s
 
 newtype BackendFlowWrapper st rt next = BackendFlowWrapper (Exists (BackendFlowCommands next st rt))
@@ -777,3 +780,6 @@ setMessageHandler dbName f = do
         ("dbName: " <> dbName <> ", setMessageHandler")
         $ Playback.mkRunKVDBSimpleEntry dbName "setMessageHandler" "")
       id
+
+parSequence :: ∀ st rt a. Array (BackendFlow st rt a) → BackendFlow st rt (Array (Either Error a))
+parSequence tbf = wrap $ ParSequence tbf id

--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -138,6 +138,7 @@ data BackendFlowCommands next st rt s
         (Playback.RRItemDict Playback.SetOptionEntry UnitEx)
         (UnitEx -> next)
 
+    -- Can't be used for flows which shares it states in parallel computation.
     | ParSequence (Array (BackendFlow st rt s))
         (Array (Either Error s) → next)
 

--- a/src/Presto/Backend/Runtime/Interpreter.purs
+++ b/src/Presto/Backend/Runtime/Interpreter.purs
@@ -27,34 +27,37 @@ module Presto.Backend.Runtime.Interpreter
 import Prelude
 
 import Control.Monad.Aff (forkAff)
-import Control.Monad.Aff.AVar (AVAR, AVar, makeVar, readVar, takeVar, putVar)
+import Control.Monad.Aff.AVar (makeVar, putVar, readVar, takeVar)
 import Control.Monad.Aff.Class (liftAff)
-import Control.Monad.Eff.Exception (Error, throwException, error)
 import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Except.Trans (runExceptT) as E
 import Control.Monad.Free (foldFree)
 import Control.Monad.Reader.Trans (ask, lift, runReaderT) as R
 import Control.Monad.State.Trans (get, modify, put, runStateT) as S
+import Control.Parallel (parSequence)
+import Data.Array (foldl, (:))
+import Data.Bifunctor (bimap)
 import Data.Exists (runExists)
-import Data.Tuple (Tuple)
-import Data.StrMap as StrMap
-import Data.UUID (genUUID)
 import Data.Maybe (Maybe(..))
+import Data.StrMap as StrMap
+import Data.Tuple (Tuple, fst)
+import Data.UUID (genUUID)
+import Presto.Backend.DB.Mock.Types (DBActionDict)
 import Presto.Backend.Flow (BackendFlow, BackendFlowCommands(..), BackendFlowCommandsWrapper, BackendFlowWrapper(..))
-import Presto.Backend.SystemCommands (runSysCmd)
-import Presto.Backend.Language.Types.EitherEx (fromEitherEx, toEitherEx)
-import Presto.Backend.Language.Types.MaybeEx (fromMaybeEx, toMaybeEx)
-import Presto.Backend.Language.Types.UnitEx (UnitEx(..), fromUnitEx)
 import Presto.Backend.Language.Types.DB (SqlConn(..))
+import Presto.Backend.Language.Types.EitherEx (fromEitherEx)
+import Presto.Backend.Language.Types.MaybeEx (fromMaybeEx, toMaybeEx)
+import Presto.Backend.Language.Types.UnitEx (UnitEx(UnitEx))
+import Presto.Backend.Playback.Entries (mkThrowExceptionEntry)
+import Presto.Backend.Playback.Machine.Classless (withRunModeClassless)
+import Presto.Backend.Playback.Types (PlaybackError(PlaybackError), PlaybackErrorType(ForkedFlowRecordingsMissed), PlayerRuntime, RecorderRuntime, mkEntryDict)
+import Presto.Backend.Runtime.API (runAPIInteraction)
 import Presto.Backend.Runtime.Common (lift3, throwException', getDBConn', getKVDBConn')
+import Presto.Backend.Runtime.KVDBInterpreter (runKVDB)
 import Presto.Backend.Runtime.Types (InterpreterMT, InterpreterMT', BackendRuntime(..), RunningMode(..))
 import Presto.Backend.Runtime.Types as X
-import Presto.Backend.Playback.Machine.Classless (withRunModeClassless)
-import Presto.Backend.Playback.Entries (mkThrowExceptionEntry)
-import Presto.Backend.Playback.Types (RecorderRuntime(..), PlayerRuntime(..), PlaybackError(..), PlaybackErrorType(..), mkEntryDict)
-import Presto.Backend.Runtime.API (runAPIInteraction)
-import Presto.Backend.Runtime.KVDBInterpreter (runKVDB)
-import Presto.Backend.DB.Mock.Types (DBActionDict)
+import Presto.Backend.SystemCommands (runSysCmd)
 
 forkF :: forall eff rt st a. BackendRuntime -> BackendFlow st rt a -> InterpreterMT rt st (Tuple Error st) eff Unit
 forkF brt flow = do
@@ -236,6 +239,14 @@ interpret brt (RunKVDBEither dbName kvDBF mockedKvDbActDictF rrItemDict next) =
 
 interpret brt (RunKVDBSimple dbName kvDBF mockedKvDbActDictF rrItemDict next) =
   next <$> runKVDB brt dbName kvDBF mockedKvDbActDictF rrItemDict
+
+interpret brt@(BackendRuntime rt) (ParSequence aflow next) = do
+  st ← R.lift S.get
+  reader ← R.ask
+  (next <<< map (bimap fst fst)) <$> (lift3 $ parSequence $ foldl (flowToAff st reader) [] aflow)
+
+  where
+    flowToAff st reader acc flow = E.runExceptT (S.runStateT (R.runReaderT (runBackend brt flow) reader) st) : acc
 
 runBackend :: forall st rt eff a. BackendRuntime -> BackendFlow st rt a -> InterpreterMT' rt st eff a
 runBackend backendRuntime = foldFree (\(BackendFlowWrapper x) -> runExists (interpret backendRuntime) x)


### PR DESCRIPTION
We need to run an Array of Backendflow in parallel, we can't actually do a parSequence or parTraverse on Backendflow as it requires instance on PARALLEL, to create an instance on parallel we need backend runner, it won't available outside. To overcome this we added parSequence in DSL so that it internally refers to the parallel instance underlying Aff