### PR TITLE
Handle Redis Failover.

### DIFF
--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -124,6 +124,12 @@ data BackendFlowCommands next st rt s
         (Playback.RRItemDict Playback.RunKVDBEitherEntry (EitherEx DBError s))
         (EitherEx DBError s -> next)
 
+    | RunKVDBEither' String
+        (KVDB.KVDB (EitherEx DBError s))
+        (MockedKVDBConn -> KVDBMock.KVDBActionDict)
+        (Playback.RRItemDict Playback.RunKVDBEitherEntry (EitherEx DBError s))
+        (EitherEx DBError s -> next)
+
     | RunKVDBSimple String
         (KVDB.KVDB s)
         (MockedKVDBConn -> KVDBMock.KVDBActionDict)
@@ -416,7 +422,7 @@ getKVDBConn dbName = wrap $ GetKVDBConn dbName
 -- Should we wrap Unit?
 setCache :: forall st rt. String -> String ->  String -> BackendFlow st rt (Either Error Unit)
 setCache dbName key value = do
-  eRes <- wrap $ RunKVDBEither dbName
+  eRes <- wrap $ RunKVDBEither' dbName
       (toCustomEitherExF toUnitEx <$> KVDB.setCache key value Nothing)
       KVDBMock.mkKVDBActionDict
       (Playback.mkEntryDict
@@ -427,7 +433,7 @@ setCache dbName key value = do
 
 setCacheWithOpts :: forall st rt. String -> String ->  String -> Maybe Milliseconds -> SetOptions -> BackendFlow st rt (Either Error Boolean)
 setCacheWithOpts dbName key value mbTtl opts = do
-  eRes <- wrap $ RunKVDBEither dbName
+  eRes <- wrap $ RunKVDBEither' dbName
           ((toEitherEx <<< bimap toDBError id) <$> KVDB.setCacheWithOpts key value mbTtl opts)
           KVDBMock.mkKVDBActionDict
           (Playback.mkEntryDict
@@ -440,7 +446,7 @@ setCacheWithOpts dbName key value mbTtl opts = do
 -- Should we wrap Unit?
 setCacheWithExpiry :: forall st rt. String -> String -> String -> Milliseconds -> BackendFlow st rt (Either Error Unit)
 setCacheWithExpiry dbName key value ttl = do
-  eRes <- wrap $ RunKVDBEither dbName
+  eRes <- wrap $ RunKVDBEither' dbName
       (toCustomEitherExF toUnitEx <$> KVDB.setCache key value (Just ttl))
       KVDBMock.mkKVDBActionDict
       (Playback.mkEntryDict
@@ -451,7 +457,7 @@ setCacheWithExpiry dbName key value ttl = do
 
 getCache :: forall st rt. String -> String -> BackendFlow st rt (Either Error (Maybe String))
 getCache dbName key = do
-  eRes <- wrap $ RunKVDBEither dbName
+  eRes <- wrap $ RunKVDBEither' dbName
       (toDBMaybeResult <$> KVDB.getCache key)
       KVDBMock.mkKVDBActionDict
       (Playback.mkEntryDict

--- a/src/Presto/Backend/Language/Flow.purs
+++ b/src/Presto/Backend/Language/Flow.purs
@@ -124,12 +124,6 @@ data BackendFlowCommands next st rt s
         (Playback.RRItemDict Playback.RunKVDBEitherEntry (EitherEx DBError s))
         (EitherEx DBError s -> next)
 
-    | RunKVDBEither' String
-        (KVDB.KVDB (EitherEx DBError s))
-        (MockedKVDBConn -> KVDBMock.KVDBActionDict)
-        (Playback.RRItemDict Playback.RunKVDBEitherEntry (EitherEx DBError s))
-        (EitherEx DBError s -> next)
-
     | RunKVDBSimple String
         (KVDB.KVDB s)
         (MockedKVDBConn -> KVDBMock.KVDBActionDict)
@@ -422,7 +416,7 @@ getKVDBConn dbName = wrap $ GetKVDBConn dbName
 -- Should we wrap Unit?
 setCache :: forall st rt. String -> String ->  String -> BackendFlow st rt (Either Error Unit)
 setCache dbName key value = do
-  eRes <- wrap $ RunKVDBEither' dbName
+  eRes <- wrap $ RunKVDBEither dbName
       (toCustomEitherExF toUnitEx <$> KVDB.setCache key value Nothing)
       KVDBMock.mkKVDBActionDict
       (Playback.mkEntryDict
@@ -433,7 +427,7 @@ setCache dbName key value = do
 
 setCacheWithOpts :: forall st rt. String -> String ->  String -> Maybe Milliseconds -> SetOptions -> BackendFlow st rt (Either Error Boolean)
 setCacheWithOpts dbName key value mbTtl opts = do
-  eRes <- wrap $ RunKVDBEither' dbName
+  eRes <- wrap $ RunKVDBEither dbName
           ((toEitherEx <<< bimap toDBError id) <$> KVDB.setCacheWithOpts key value mbTtl opts)
           KVDBMock.mkKVDBActionDict
           (Playback.mkEntryDict
@@ -446,7 +440,7 @@ setCacheWithOpts dbName key value mbTtl opts = do
 -- Should we wrap Unit?
 setCacheWithExpiry :: forall st rt. String -> String -> String -> Milliseconds -> BackendFlow st rt (Either Error Unit)
 setCacheWithExpiry dbName key value ttl = do
-  eRes <- wrap $ RunKVDBEither' dbName
+  eRes <- wrap $ RunKVDBEither dbName
       (toCustomEitherExF toUnitEx <$> KVDB.setCache key value (Just ttl))
       KVDBMock.mkKVDBActionDict
       (Playback.mkEntryDict
@@ -457,7 +451,7 @@ setCacheWithExpiry dbName key value ttl = do
 
 getCache :: forall st rt. String -> String -> BackendFlow st rt (Either Error (Maybe String))
 getCache dbName key = do
-  eRes <- wrap $ RunKVDBEither' dbName
+  eRes <- wrap $ RunKVDBEither dbName
       (toDBMaybeResult <$> KVDB.getCache key)
       KVDBMock.mkKVDBActionDict
       (Playback.mkEntryDict

--- a/src/Presto/Backend/Runtime/Common.purs
+++ b/src/Presto/Backend/Runtime/Common.purs
@@ -63,10 +63,10 @@ getKVDBConn' brt@(BackendRuntime rt) dbName = do
     Just (SqlConn _)         -> throwException' "Found SQL DB Connection instead KV DB Connection."
     _                        -> throwException' "No DB found"
 
-getKVDBConn :: forall st rt eff. BackendRuntime -> String -> InterpreterMT' rt st eff (Either String KVDBConn)
-getKVDBConn brt@(BackendRuntime rt) dbName = do
+getKVDBConnection :: forall st rt eff. BackendRuntime -> String -> InterpreterMT' rt st eff (Either String KVDBConn)
+getKVDBConnection brt@(BackendRuntime rt) dbName = do
   let mbConn = lookup dbName rt.connections
   case mbConn of
     Just (KVDBConn kvDBConn) -> pure $ Right kvDBConn
     Just (SqlConn _)         -> pure $ Left "Found SQL DB Connection instead KV DB Connection."
-    _                        -> pure $ Left "No DB found"
+    _                        -> pure $ Left "No DB Connection found"

--- a/src/Presto/Backend/Runtime/Common.purs
+++ b/src/Presto/Backend/Runtime/Common.purs
@@ -62,3 +62,11 @@ getKVDBConn' brt@(BackendRuntime rt) dbName = do
     Just (KVDBConn kvDBConn) -> pure kvDBConn
     Just (SqlConn _)         -> throwException' "Found SQL DB Connection instead KV DB Connection."
     _                        -> throwException' "No DB found"
+
+getKVDBConn :: forall st rt eff. BackendRuntime -> String -> InterpreterMT' rt st eff (Either String KVDBConn)
+getKVDBConn brt@(BackendRuntime rt) dbName = do
+  let mbConn = lookup dbName rt.connections
+  case mbConn of
+    Just (KVDBConn kvDBConn) -> pure $ Right kvDBConn
+    Just (SqlConn _)         -> pure $ Left "Found SQL DB Connection instead KV DB Connection."
+    _                        -> pure $ Left "No DB found"

--- a/src/Presto/Backend/Runtime/Interpreter.purs
+++ b/src/Presto/Backend/Runtime/Interpreter.purs
@@ -54,7 +54,7 @@ import Presto.Backend.Playback.Machine.Classless (withRunModeClassless)
 import Presto.Backend.Playback.Types (PlaybackError(PlaybackError), PlaybackErrorType(ForkedFlowRecordingsMissed), PlayerRuntime, RecorderRuntime, mkEntryDict)
 import Presto.Backend.Runtime.API (runAPIInteraction)
 import Presto.Backend.Runtime.Common (lift3, throwException', getDBConn', getKVDBConn')
-import Presto.Backend.Runtime.KVDBInterpreter (runKVDB)
+import Presto.Backend.Runtime.KVDBInterpreter (runKVDB, runKVDBEither')
 import Presto.Backend.Runtime.Types (InterpreterMT, InterpreterMT', BackendRuntime(..), RunningMode(..))
 import Presto.Backend.Runtime.Types as X
 import Presto.Backend.SystemCommands (runSysCmd)
@@ -236,6 +236,9 @@ interpret brt@(BackendRuntime rt) (GetKVDBConn dbName rrItemDict next) = do
 
 interpret brt (RunKVDBEither dbName kvDBF mockedKvDbActDictF rrItemDict next) =
   next <$> runKVDB brt dbName kvDBF mockedKvDbActDictF rrItemDict
+
+interpret brt (RunKVDBEither' dbName kvDBF mockedKvDbActDictF rrItemDict next) =
+  next <$> runKVDBEither' brt dbName kvDBF mockedKvDbActDictF rrItemDict
 
 interpret brt (RunKVDBSimple dbName kvDBF mockedKvDbActDictF rrItemDict next) =
   next <$> runKVDB brt dbName kvDBF mockedKvDbActDictF rrItemDict

--- a/src/Presto/Backend/Runtime/Interpreter.purs
+++ b/src/Presto/Backend/Runtime/Interpreter.purs
@@ -54,7 +54,7 @@ import Presto.Backend.Playback.Machine.Classless (withRunModeClassless)
 import Presto.Backend.Playback.Types (PlaybackError(PlaybackError), PlaybackErrorType(ForkedFlowRecordingsMissed), PlayerRuntime, RecorderRuntime, mkEntryDict)
 import Presto.Backend.Runtime.API (runAPIInteraction)
 import Presto.Backend.Runtime.Common (lift3, throwException', getDBConn', getKVDBConn')
-import Presto.Backend.Runtime.KVDBInterpreter (runKVDB, runKVDBEither')
+import Presto.Backend.Runtime.KVDBInterpreter (runKVDB, runKVDBEither)
 import Presto.Backend.Runtime.Types (InterpreterMT, InterpreterMT', BackendRuntime(..), RunningMode(..))
 import Presto.Backend.Runtime.Types as X
 import Presto.Backend.SystemCommands (runSysCmd)
@@ -235,7 +235,7 @@ interpret brt@(BackendRuntime rt) (GetKVDBConn dbName rrItemDict next) = do
   pure $ next res
 
 interpret brt (RunKVDBEither dbName kvDBF mockedKvDbActDictF rrItemDict next) =
-  next <$> runKVDBEither' brt dbName kvDBF mockedKvDbActDictF rrItemDict
+  next <$> runKVDBEither brt dbName kvDBF mockedKvDbActDictF rrItemDict
 
 interpret brt (RunKVDBSimple dbName kvDBF mockedKvDbActDictF rrItemDict next) =
   next <$> runKVDB brt dbName kvDBF mockedKvDbActDictF rrItemDict

--- a/src/Presto/Backend/Runtime/Interpreter.purs
+++ b/src/Presto/Backend/Runtime/Interpreter.purs
@@ -235,9 +235,6 @@ interpret brt@(BackendRuntime rt) (GetKVDBConn dbName rrItemDict next) = do
   pure $ next res
 
 interpret brt (RunKVDBEither dbName kvDBF mockedKvDbActDictF rrItemDict next) =
-  next <$> runKVDB brt dbName kvDBF mockedKvDbActDictF rrItemDict
-
-interpret brt (RunKVDBEither' dbName kvDBF mockedKvDbActDictF rrItemDict next) =
   next <$> runKVDBEither' brt dbName kvDBF mockedKvDbActDictF rrItemDict
 
 interpret brt (RunKVDBSimple dbName kvDBF mockedKvDbActDictF rrItemDict next) =

--- a/src/Presto/Backend/Runtime/KVDBInterpreter.purs
+++ b/src/Presto/Backend/Runtime/KVDBInterpreter.purs
@@ -21,7 +21,7 @@
 
 module Presto.Backend.Runtime.KVDBInterpreter
   ( runKVDB
-  , runKVDBEither'
+  , runKVDBEither
   ) where
 
 import Prelude
@@ -291,7 +291,7 @@ runKVDB brt dbName kvDBAct mockedKvDbActDictF rrItemDict = do
     MockedKVDB mocked -> withRunModeClassless brt rrItemDict
         (getMockedKVDBValue brt $ mockedKvDbActDictF mocked)
 
-runKVDBEither'
+runKVDBEither
   :: forall st rt eff rrItem a
    . BackendRuntime
   -> String
@@ -299,7 +299,7 @@ runKVDBEither'
   -> (MockedKVDBConn -> KVDBActionDict)
   -> RRItemDict rrItem (EitherEx DBError a)
   -> InterpreterMT' rt st eff (EitherEx DBError a)
-runKVDBEither' brt dbName kvDBAct mockedKvDbActDictF rrItemDict = do
+runKVDBEither brt dbName kvDBAct mockedKvDbActDictF rrItemDict = do
   eitherConn <- getKVDBConnection brt dbName
   case eitherConn of
     Right (Redis simpleConn) ->

--- a/src/Presto/Backend/Runtime/KVDBInterpreter.purs
+++ b/src/Presto/Backend/Runtime/KVDBInterpreter.purs
@@ -50,7 +50,7 @@ import Presto.Backend.Language.Types.DB (KVDBConn(MockedKVDB, Redis), MockedKVDB
 import Presto.Backend.Language.Types.KVDB (Multi(..), getMultiGUID)
 import Presto.Backend.Playback.Machine.Classless (withRunModeClassless)
 import Presto.Backend.Playback.Types (RRItemDict)
-import Presto.Backend.Runtime.Common (getKVDBConn', getKVDBConn, lift3, throwException')
+import Presto.Backend.Runtime.Common (getKVDBConn', getKVDBConnection, lift3, throwException')
 import Presto.Backend.Runtime.Types (BackendRuntime(BackendRuntime), InterpreterMT', KVDBRuntime(KVDBRuntime))
 
 
@@ -300,7 +300,7 @@ runKVDBEither'
   -> RRItemDict rrItem (EitherEx DBError a)
   -> InterpreterMT' rt st eff (EitherEx DBError a)
 runKVDBEither' brt dbName kvDBAct mockedKvDbActDictF rrItemDict = do
-  eitherConn <- getKVDBConn brt dbName
+  eitherConn <- getKVDBConnection brt dbName
   case eitherConn of
     Right (Redis simpleConn) ->
       withRunModeClassless brt rrItemDict (runKVDB' brt dbName simpleConn kvDBAct)

--- a/src/Presto/Backend/Runtime/KVDBInterpreter.purs
+++ b/src/Presto/Backend/Runtime/KVDBInterpreter.purs
@@ -21,18 +21,19 @@
 
 module Presto.Backend.Runtime.KVDBInterpreter
   ( runKVDB
+  , runKVDBEither'
   ) where
 
 import Prelude
 
 import Cache (SetOptions(..), SimpleConn, del, exists, expire, get, incr, publish, set, setMessageHandler, subscribe)
 import Cache.Hash (hget, hset)
-import Cache.Multi as Native
 import Cache.List (lindex, lpop, rpush)
 import Cache.Multi (execMulti, expireMulti, getMulti, hgetMulti, hsetMulti, incrMulti, lindexMulti, lpopMulti, newMulti, publishMulti, rpushMulti, setMulti, subscribeMulti, xaddMulti)
+import Cache.Multi as Native
 import Control.Monad.Aff (Aff)
-import Control.Monad.Aff.Class (liftAff)
 import Control.Monad.Aff.AVar (AVAR, putVar, takeVar, readVar)
+import Control.Monad.Aff.Class (liftAff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (Error, message)
 import Control.Monad.Free (foldFree)
@@ -42,14 +43,15 @@ import Data.Exists (runExists)
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.StrMap as StrMap
 import Data.UUID (GENUUID, genUUID)
+import Presto.Backend.KVDB.Mock.Types (KVDBActionDict)
 import Presto.Backend.Language.KVDB (KVDB, KVDBMethod(..), KVDBMethodWrapper, KVDBWrapper(..))
+import Presto.Backend.Language.Types (DBError(..), EitherEx(..))
 import Presto.Backend.Language.Types.DB (KVDBConn(MockedKVDB, Redis), MockedKVDBConn)
 import Presto.Backend.Language.Types.KVDB (Multi(..), getMultiGUID)
-import Presto.Backend.KVDB.Mock.Types (KVDBActionDict)
-import Presto.Backend.Runtime.Common (getKVDBConn', lift3, throwException')
-import Presto.Backend.Runtime.Types (BackendRuntime(BackendRuntime), InterpreterMT', KVDBRuntime(KVDBRuntime))
-import Presto.Backend.Playback.Types (RRItemDict)
 import Presto.Backend.Playback.Machine.Classless (withRunModeClassless)
+import Presto.Backend.Playback.Types (RRItemDict)
+import Presto.Backend.Runtime.Common (getKVDBConn', getKVDBConn, lift3, throwException')
+import Presto.Backend.Runtime.Types (BackendRuntime(BackendRuntime), InterpreterMT', KVDBRuntime(KVDBRuntime))
 
 
 getMockedKVDBValue :: forall st rt eff a. BackendRuntime -> KVDBActionDict -> InterpreterMT' rt st eff a
@@ -288,3 +290,27 @@ runKVDB brt dbName kvDBAct mockedKvDbActDictF rrItemDict = do
         (runKVDB' brt dbName simpleConn kvDBAct)
     MockedKVDB mocked -> withRunModeClassless brt rrItemDict
         (getMockedKVDBValue brt $ mockedKvDbActDictF mocked)
+
+
+runKVDBEither'
+  :: forall st rt eff rrItem a
+   . BackendRuntime
+  -> String
+  -> KVDB (EitherEx DBError a)
+  -> (MockedKVDBConn -> KVDBActionDict)
+  -> RRItemDict rrItem (EitherEx DBError a)
+  -> InterpreterMT' rt st eff (EitherEx DBError a)
+runKVDBEither' brt dbName kvDBAct mockedKvDbActDictF rrItemDict = do
+  eitherConn <- getKVDBConn brt dbName
+  case eitherConn of
+    Right (Redis simpleConn) -> do
+      res <- withRunModeClassless brt rrItemDict (runKVDB' brt dbName simpleConn kvDBAct)
+      case res of
+        RightEx val -> pure $  RightEx val
+        LeftEx err -> pure $ LeftEx err
+    Right (MockedKVDB mocked) -> do
+      res <- withRunModeClassless brt rrItemDict (getMockedKVDBValue brt $ mockedKvDbActDictF mocked)
+      case res of
+        RightEx val -> pure $ RightEx val
+        LeftEx err -> pure $ LeftEx err
+    Left err -> pure $ LeftEx (DBError err)

--- a/src/Presto/Backend/Runtime/KVDBInterpreter.purs
+++ b/src/Presto/Backend/Runtime/KVDBInterpreter.purs
@@ -291,7 +291,6 @@ runKVDB brt dbName kvDBAct mockedKvDbActDictF rrItemDict = do
     MockedKVDB mocked -> withRunModeClassless brt rrItemDict
         (getMockedKVDBValue brt $ mockedKvDbActDictF mocked)
 
-
 runKVDBEither'
   :: forall st rt eff rrItem a
    . BackendRuntime
@@ -303,14 +302,8 @@ runKVDBEither'
 runKVDBEither' brt dbName kvDBAct mockedKvDbActDictF rrItemDict = do
   eitherConn <- getKVDBConn brt dbName
   case eitherConn of
-    Right (Redis simpleConn) -> do
-      res <- withRunModeClassless brt rrItemDict (runKVDB' brt dbName simpleConn kvDBAct)
-      case res of
-        RightEx val -> pure $  RightEx val
-        LeftEx err -> pure $ LeftEx err
-    Right (MockedKVDB mocked) -> do
-      res <- withRunModeClassless brt rrItemDict (getMockedKVDBValue brt $ mockedKvDbActDictF mocked)
-      case res of
-        RightEx val -> pure $ RightEx val
-        LeftEx err -> pure $ LeftEx err
+    Right (Redis simpleConn) ->
+      withRunModeClassless brt rrItemDict (runKVDB' brt dbName simpleConn kvDBAct)
+    Right (MockedKVDB mocked) ->
+      withRunModeClassless brt rrItemDict (getMockedKVDBValue brt $ mockedKvDbActDictF mocked)
     Left err -> pure $ LeftEx (DBError err)


### PR DESCRIPTION
Problem Statement:

In runKvDBEither, we were using getKvDbConn' which threw an exception if it was unable to find a connection. This led to application throwing 500s when the redis connection was not available.

Solution:

Create another function, getKVDBConnection, which returns an Either Error connection. This will help to expose the error to the application, which can handle these scenarios as they want to.

Add a new command runKVDBEither', which will use the new fn - getKVDBConnection and add to the commands which need to be used by the application.

test cases:

This code has been tested by doing deployment in sandbox environment and simulating redis failure scenarios.
